### PR TITLE
4664 OpenAIRE compliance: AlternativeTitle and geoLocations 

### DIFF
--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -1132,6 +1132,7 @@ dataset.exportBtn.itemLabel.ddi=DDI
 dataset.exportBtn.itemLabel.dublinCore=Dublin Core
 dataset.exportBtn.itemLabel.schemaDotOrg=Schema.org JSON-LD
 dataset.exportBtn.itemLabel.json=JSON
+dataset.exportBtn.itemLabel.dataciteOpenAIRE=DataCite OpenAIRE
 metrics.title=Metrics
 metrics.title.tip=View more metrics information
 metrics.comingsoon=Coming soon...

--- a/src/main/java/edu/harvard/iq/dataverse/export/OpenAireExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/OpenAireExporter.java
@@ -1,7 +1,6 @@
 package edu.harvard.iq.dataverse.export;
 
 import java.io.OutputStream;
-import java.util.logging.Logger;
 
 import javax.json.JsonObject;
 import javax.xml.stream.XMLStreamException;
@@ -15,29 +14,24 @@ import edu.harvard.iq.dataverse.util.BundleUtil;
 
 @AutoService(Exporter.class)
 public class OpenAireExporter implements Exporter {
-    Logger logger = Logger.getLogger(OpenAireExporter.class.getCanonicalName());
     
 	public OpenAireExporter() {
-		logger.info("entering in OpenAireExporter constructor");
 	}
 
 	@Override
 	public String getProviderName() {
-		logger.info("entering in the method getProviderName() of OpenAIRE");
 		return "oai_datacite";
 	}
+	
 
 	@Override
 	public String getDisplayName() {
-		logger.info("entering in getDisplayName() of OpenAIRE");
-		// add this into the dataverse/src/main/java/Bundle.properties (it is present into applications/dataverse-4.8.6/WEB-INF/classes)
-		return  BundleUtil.getStringFromBundle("dataset.exportBtn.itemLabel.dataciteOpenAIRE") != null ? BundleUtil.getStringFromBundle("dataset.exportBtn.itemLabel.dataciteOpenAIRE") : "DataCite OpenAIRE";
+            return BundleUtil.getStringFromBundle("dataset.exportBtn.itemLabel.dataciteOpenAIRE");
 	}
 
 	@Override
 	public void exportDataset(DatasetVersion version, JsonObject json, OutputStream outputStream)
 			throws ExportException {
-		logger.info("entering into exportDataset() of OpenAIRE");
 		try {
             OpenAireExportUtil.datasetJson2openaire(json, outputStream);
 		} catch (XMLStreamException xse) {
@@ -57,17 +51,17 @@ public class OpenAireExporter implements Exporter {
 
 	@Override
 	public Boolean isAvailableToUsers() {
-		return false;
+		return true;
 	}
 
 	@Override
 	public String getXMLNameSpace() throws ExportException {
-		return OpenAireExportUtil.OAI_DATACITE_NAMESPACE;
+		return OpenAireExportUtil.RESOURCE_NAMESPACE;
 	}
 
 	@Override
 	public String getXMLSchemaLocation() throws ExportException {
-		return OpenAireExportUtil.OAI_DATACITE_SCHEMA_LOCATION;
+		return OpenAireExportUtil.RESOURCE_SCHEMA_LOCATION;
 	}
 
 	@Override

--- a/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExporterTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/export/OpenAireExporterTest.java
@@ -1,0 +1,178 @@
+package edu.harvard.iq.dataverse.export;
+
+import com.jayway.restassured.path.xml.XmlPath;
+import com.jayway.restassured.path.xml.element.Node;
+import com.jayway.restassured.path.xml.element.NodeChildren;
+import edu.harvard.iq.dataverse.DatasetVersion;
+import edu.harvard.iq.dataverse.util.xml.XmlPrinter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import static junit.framework.Assert.assertEquals;
+import org.junit.Test;
+
+public class OpenAireExporterTest {
+
+    private final OpenAireExporter openAireExporter;
+
+    public OpenAireExporterTest() {
+        openAireExporter = new OpenAireExporter();
+    }
+
+    /**
+     * Test of getProviderName method, of class OpenAireExporter.
+     */
+    @Test
+    public void testGetProviderName() {
+        System.out.println("getProviderName");
+        OpenAireExporter instance = new OpenAireExporter();
+        String expResult = "oai_datacite";
+        String result = instance.getProviderName();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getDisplayName method, of class OpenAireExporter.
+     */
+    @Test
+    public void testGetDisplayName() {
+        System.out.println("getDisplayName");
+        OpenAireExporter instance = new OpenAireExporter();
+        String expResult = "DataCite OpenAIRE";
+        String result = instance.getDisplayName();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of exportDataset method, of class OpenAireExporter.
+     */
+    @Test
+    public void testExportDataset() throws Exception {
+        System.out.println("exportDataset");
+        // TODO: add more fields to json to increase code coverage.
+        File datasetVersionJson = new File("src/test/java/edu/harvard/iq/dataverse/export/dataset-spruce1.json");
+        String datasetVersionAsJson = new String(Files.readAllBytes(Paths.get(datasetVersionJson.getAbsolutePath())));
+        JsonReader jsonReader = Json.createReader(new StringReader(datasetVersionAsJson));
+        JsonObject jsonObject = jsonReader.readObject();
+        DatasetVersion nullVersion = null;
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        openAireExporter.exportDataset(nullVersion, jsonObject, byteArrayOutputStream);
+        String xmlOnOneLine = new String(byteArrayOutputStream.toByteArray());
+        String xmlAsString = XmlPrinter.prettyPrintXml(xmlOnOneLine);
+        System.out.println("XML: " + xmlAsString);
+        XmlPath xmlpath = XmlPath.from(xmlAsString);
+        assertEquals("Spruce Goose", xmlpath.getString("resource.titles.title"));
+        assertEquals("Spruce, Sabrina", xmlpath.getString("resource.creators.creator"));
+        assertEquals("1.0", xmlpath.getString("resource.version"));
+        
+        datasetVersionJson = new File("src/test/java/edu/harvard/iq/dataverse/export/backToFuture.json");
+        datasetVersionAsJson = new String(Files.readAllBytes(Paths.get(datasetVersionJson.getAbsolutePath())));
+        jsonReader = Json.createReader(new StringReader(datasetVersionAsJson));
+        jsonObject = jsonReader.readObject();
+        nullVersion = null;
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        openAireExporter.exportDataset(nullVersion, jsonObject, byteArrayOutputStream);
+        xmlOnOneLine = new String(byteArrayOutputStream.toByteArray());
+        xmlAsString = XmlPrinter.prettyPrintXml(xmlOnOneLine);
+        System.out.println("XML: " + xmlAsString);
+        xmlpath = XmlPath.from(xmlAsString);
+        assertEquals("Back to the Future", xmlpath.getList("resource.titles.title").get(0));
+        assertEquals("Robert Zemeckis", xmlpath.getString("resource.creators.creator.creatorName"));
+        assertEquals("0001-0002-0003-0004", xmlpath.get("resource.creators.creator.nameIdentifier.findAll {it.@nameIdentifierScheme == 'ORCID'}"));
+        assertEquals("1985-01", xmlpath.get("resource.dates.date.findAll { it.@dateType == 'Created'}"));
+        assertEquals("1985-01-01", xmlpath.get("resource.dates.date.findAll { it.@dateType == 'Issued'}"));
+        assertEquals("1985-02/1985-03", xmlpath.get("resource.dates.date.findAll { it.@dateType == 'Collected'}"));
+        assertEquals("United States; California; Hill Valley; fantasy cityHill Valley City32.64542843   116.36588226", xmlpath.getString("resources.geoLocations.geoLocation.geoLocationPlace"));
+
+    }
+
+    /**
+     * Test of isXMLFormat method, of class OpenAireExporter.
+     */
+    @Test
+    public void testIsXMLFormat() {
+        System.out.println("isXMLFormat");
+        OpenAireExporter instance = new OpenAireExporter();
+        Boolean expResult = true;
+        Boolean result = instance.isXMLFormat();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of isHarvestable method, of class OpenAireExporter.
+     */
+    @Test
+    public void testIsHarvestable() {
+        System.out.println("isHarvestable");
+        OpenAireExporter instance = new OpenAireExporter();
+        Boolean expResult = true;
+        Boolean result = instance.isHarvestable();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of isAvailableToUsers method, of class OpenAireExporter.
+     */
+    @Test
+    public void testIsAvailableToUsers() {
+        System.out.println("isAvailableToUsers");
+        OpenAireExporter instance = new OpenAireExporter();
+        Boolean expResult = true;
+        Boolean result = instance.isAvailableToUsers();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getXMLNameSpace method, of class OpenAireExporter.
+     */
+    @Test
+    public void testGetXMLNameSpace() throws Exception {
+        System.out.println("getXMLNameSpace");
+        OpenAireExporter instance = new OpenAireExporter();
+        String expResult = "http://datacite.org/schema/kernel-4";
+        String result = instance.getXMLNameSpace();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getXMLSchemaLocation method, of class OpenAireExporter.
+     */
+    @Test
+    public void testGetXMLSchemaLocation() throws Exception {
+        System.out.println("getXMLSchemaLocation");
+        OpenAireExporter instance = new OpenAireExporter();
+        String expResult = "http://schema.datacite.org/meta/kernel-4.1/metadata.xsd";
+        String result = instance.getXMLSchemaLocation();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getXMLSchemaVersion method, of class OpenAireExporter.
+     */
+    @Test
+    public void testGetXMLSchemaVersion() throws Exception {
+        System.out.println("getXMLSchemaVersion");
+        OpenAireExporter instance = new OpenAireExporter();
+        String expResult = "4.1";
+        String result = instance.getXMLSchemaVersion();
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of setParam method, of class OpenAireExporter.
+     */
+    @Test
+    public void testSetParam() {
+        System.out.println("setParam");
+        String name = "";
+        Object value = null;
+        OpenAireExporter instance = new OpenAireExporter();
+        instance.setParam(name, value);
+    }
+
+}

--- a/src/test/java/edu/harvard/iq/dataverse/export/backToFuture.json
+++ b/src/test/java/edu/harvard/iq/dataverse/export/backToFuture.json
@@ -1,0 +1,544 @@
+{
+    "id": 2556,
+    "identifier": "JR6WQX",
+    "persistentUrl": "http://dx.doi.org/10.21950/JR6WQX",
+    "protocol": "doi",
+    "authority": "10.21950",
+    "publisher": "e-cienciaDatos",
+    "publicationDate": "2018-06-03",
+    "datasetVersion": {
+        "id": 757,
+        "versionNumber": 1,
+        "versionMinorNumber": 0,
+        "versionState": "RELEASED",
+        "distributionDate": "1985-01-01",
+        "productionDate": "Production Date",
+        "lastUpdateTime": "2018-06-03T07:21:50Z",
+        "releaseTime": "2018-06-03T07:21:50Z",
+        "createTime": "2018-06-03T06:57:28Z",
+        "license": "NONE",
+        "termsOfUse": "<p><img src=\"https://licensebuttons.net/l/by/4.0/88x31.png\"/>  This work is licensed under a <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution 4.0 International License.</a></p> ",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [{
+                        "typeName": "title",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Back to the Future"
+                    }, {
+                        "typeName": "subtitle",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Part I"
+                    }, {
+                        "typeName": "alternativeTitle",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Regreso al futuro"
+                    }, {
+                        "typeName": "alternativeURL",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "https://www.filmaffinity.com/en/film309023.html"
+                    }, {
+                        "typeName": "otherId",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "otherIdAgency": {
+                                    "typeName": "otherIdAgency",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "filmaffinity"
+                                },
+                                "otherIdValue": {
+                                    "typeName": "otherIdValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "film309023"
+                                }
+                            }]
+                    }, {
+                        "typeName": "author",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "authorName": {
+                                    "typeName": "authorName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Robert Zemeckis"
+                                },
+                                "authorAffiliation": {
+                                    "typeName": "authorAffiliation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "University of Southern California"
+                                },
+                                "authorIdentifierScheme": {
+                                    "typeName": "authorIdentifierScheme",
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "value": "ORCID"
+                                },
+                                "authorIdentifier": {
+                                    "typeName": "authorIdentifier",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "0001-0002-0003-0004"
+                                }
+                            }]
+                    }, {
+                        "typeName": "datasetContact",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "datasetContactName": {
+                                    "typeName": "datasetContactName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Robert Zemeckis (contact)"
+                                },
+                                "datasetContactAffiliation": {
+                                    "typeName": "datasetContactAffiliation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "University of Southern California (Contact"
+                                },
+                                "datasetContactEmail": {
+                                    "typeName": "datasetContactEmail",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Robert.Zemeckis@University.of.Southern.California.org"
+                                }
+                            }]
+                    }, {
+                        "typeName": "dsDescription",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "dsDescriptionValue": {
+                                    "typeName": "dsDescriptionValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Marty McFly (Michael J. Fox) is a typical 17 year old child. Marty is good friends with Doc Brown, the local crackpot scientist, who recently invented a time machine. When Marty accidently launches himself to the year 1955, he meets his dad and consequently interferes with his parent's first meeting. Marty must find a way to throw his parents together before he leaves, or he may never be born! Beyond this little difficulty, the time machine is out of fuel and Marty must find a way to power the vehicle for his return home. "
+                                },
+                                "dsDescriptionDate": {
+                                    "typeName": "dsDescriptionDate",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "1985"
+                                }
+                            }]
+                    }, {
+                        "typeName": "subject",
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "value": ["Ingeniería"]
+                    }, {
+                        "typeName": "keyword",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "keywordValue": {
+                                    "typeName": "keywordValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Sci-Fi"
+                                }
+                            }, {
+                                "keywordValue": {
+                                    "typeName": "keywordValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Time Travel"
+                                },
+                                "keywordVocabularyURI": {
+                                    "typeName": "keywordVocabularyURI",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "http://www.future.net"
+                                }
+                            }, {
+                                "keywordValue": {
+                                    "typeName": "keywordValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "DeLorean"
+                                },
+                                "keywordVocabulary": {
+                                    "typeName": "keywordVocabulary",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "future cars"
+                                },
+                                "keywordVocabularyURI": {
+                                    "typeName": "keywordVocabularyURI",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "http://www.future.cars.com"
+                                }
+                            }]
+                    }, {
+                        "typeName": "topicClassification",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "topicClassValue": {
+                                    "typeName": "topicClassValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Topic classification term"
+                                },
+                                "topicClassVocab": {
+                                    "typeName": "topicClassVocab",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Topic classification Vocabulary"
+                                },
+                                "topicClassVocabURI": {
+                                    "typeName": "topicClassVocabURI",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "https://www.loc.gov/catdir/cpso/lcco/"
+                                }
+                            }]
+                    }, {
+                        "typeName": "publication",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "publicationCitation": {
+                                    "typeName": "publicationCitation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Back to the Future. Part II"
+                                },
+                                "publicationIDType": {
+                                    "typeName": "publicationIDType",
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "value": "url"
+                                },
+                                "publicationIDNumber": {
+                                    "typeName": "publicationIDNumber",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "film775323"
+                                },
+                                "publicationURL": {
+                                    "typeName": "publicationURL",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "https://www.filmaffinity.com/en/film775323.html"
+                                }
+                            }]
+                    }, {
+                        "typeName": "notesText",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "This movie picks up where the last one left off; with Doc Brown and Marty going into the future to help Marty's future offspring. After doing that they returned to their own time, only to discover that things have changed. They discovered that while in the future, Marty's nemesis, Biff Tannen got the sports book that Marty bought so that he could know the results of sports events and make a killing, but Doc Brown nixed his plans, but Tannen who overheard their conversation, got the book and the time machine and went back into the past and gave the book to himself, who has not only amassed a fortune but also extremely powerful. So Doc and Marty have to go back to when Biff got the book and get it away from him. And it seems that it was in 1955 on the night of the dance that Biff got the book. So not only must they get the book but they must also avoid the other versions of themselves."
+                    }, {
+                        "typeName": "producer",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "producerName": {
+                                    "typeName": "producerName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Universal Pictures"
+                                },
+                                "producerAffiliation": {
+                                    "typeName": "producerAffiliation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Cinema Producers"
+                                },
+                                "producerAbbreviation": {
+                                    "typeName": "producerAbbreviation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Universal"
+                                },
+                                "producerURL": {
+                                    "typeName": "producerURL",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "https://www.universalpictures.com/"
+                                },
+                                "producerLogoURL": {
+                                    "typeName": "producerLogoURL",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "https://www.universalpictures.com/assets/img/universalglobe.png"
+                                }
+                            }]
+                    }, {
+                        "typeName": "productionDate",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "1985-01"
+                    }, {
+                        "typeName": "productionPlace",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Holliwood"
+                    }, {
+                        "typeName": "contributor",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "contributorType": {
+                                    "typeName": "contributorType",
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "value": "ProjectLeader"
+                                },
+                                "contributorName": {
+                                    "typeName": "contributorName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Doc"
+                                }
+                            }]
+                    }, {
+                        "typeName": "grantNumber",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "grantNumberAgency": {
+                                    "typeName": "grantNumberAgency",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Ministry of Economy and Competitiveness"
+                                },
+                                "grantNumberValue": {
+                                    "typeName": "grantNumberValue",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "1234.5567.8899"
+                                }
+                            }]
+                    }, {
+                        "typeName": "distributor",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "distributorName": {
+                                    "typeName": "distributorName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Amblin Entertainment"
+                                },
+                                "distributorAffiliation": {
+                                    "typeName": "distributorAffiliation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Cinema Producers"
+                                },
+                                "distributorAbbreviation": {
+                                    "typeName": "distributorAbbreviation",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "AE"
+                                },
+                                "distributorURL": {
+                                    "typeName": "distributorURL",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "https://pro.imdb.com/company/co0009119/"
+                                }
+                            }]
+                    }, {
+                        "typeName": "distributionDate",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "1985-01-01"
+                    }, {
+                        "typeName": "depositor",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Admin, Dataverse"
+                    }, {
+                        "typeName": "dateOfDeposit",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "2018-06-03"
+                    }, {
+                        "typeName": "timePeriodCovered",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "timePeriodCoveredStart": {
+                                    "typeName": "timePeriodCoveredStart",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "1985"
+                                },
+                                "timePeriodCoveredEnd": {
+                                    "typeName": "timePeriodCoveredEnd",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "2017"
+                                }
+                            }]
+                    }, {
+                        "typeName": "dateOfCollection",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "dateOfCollectionStart": {
+                                    "typeName": "dateOfCollectionStart",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "1985-02"
+                                },
+                                "dateOfCollectionEnd": {
+                                    "typeName": "dateOfCollectionEnd",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "1985-03"
+                                }
+                            }]
+                    }, {
+                        "typeName": "kindOfData",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["Future information"]
+                    }, {
+                        "typeName": "series",
+                        "multiple": false,
+                        "typeClass": "compound",
+                        "value": {
+                            "seriesName": {
+                                "typeName": "seriesName",
+                                "multiple": false,
+                                "typeClass": "primitive",
+                                "value": "Back to the Future (TV Series)"
+                            },
+                            "seriesInformation": {
+                                "typeName": "seriesInformation",
+                                "multiple": false,
+                                "typeClass": "primitive",
+                                "value": "https://www.filmaffinity.com/en/film894085.html"
+                            }
+                        }
+                    }, {
+                        "typeName": "software",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "softwareName": {
+                                    "typeName": "softwareName",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "vlc"
+                                },
+                                "softwareVersion": {
+                                    "typeName": "softwareVersion",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "3.0.3"
+                                }
+                            }]
+                    }, {
+                        "typeName": "relatedMaterial",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["https://www.filmaffinity.com/en/movie-relations.php?movie-id=309023"]
+                    }, {
+                        "typeName": "relatedDatasets",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["https://www.filmaffinity.com/en/film233937.html"]
+                    }, {
+                        "typeName": "otherReferences",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["https://en.wikipedia.org/wiki/Back_to_the_Future", "https://www.imdb.com/title/tt0088763/"]
+                    }, {
+                        "typeName": "dataSources",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["https://www.filmaffinity.com/"]
+                    }, {
+                        "typeName": "originOfSources",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "World Wide Web"
+                    }, {
+                        "typeName": "characteristicOfSources",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Copy Paste"
+                    }, {
+                        "typeName": "accessToSources",
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "value": "Web Crawlers"
+                    }]
+            },
+            "geospatial": {
+                "displayName": "Geospatial Metadata",
+                "fields": [{
+                        "typeName": "geographicCoverage",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "country": {
+                                    "typeName": "country",
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "value": "United States"
+                                },
+                                "state": {
+                                    "typeName": "state",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "California"
+                                },
+                                "city": {
+                                    "typeName": "city",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "Hill Valley"
+                                },
+                                "otherGeographicCoverage": {
+                                    "typeName": "otherGeographicCoverage",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "fantasy city"
+                                }
+                            }]
+                    }, {
+                        "typeName": "geographicUnit",
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "value": ["Hill Valley City"]
+                    }, {
+                        "typeName": "geographicBoundingBox",
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "value": [{
+                                "eastLongitude": {
+                                    "typeName": "eastLongitude",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "116.36588226"
+                                },
+                                "northLongitude": {
+                                    "typeName": "northLongitude",
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "value": "32.64542843"
+                                }
+                            }]
+                    }]
+            }
+        },
+        "files": [],
+        "citation": "Robert Zemeckis, 2018, \"Back to the Future\", doi:10.21950/JR6WQX, e-cienciaDatos, V1"
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/export/dataset-spruce1.json
+++ b/src/test/java/edu/harvard/iq/dataverse/export/dataset-spruce1.json
@@ -1,0 +1,86 @@
+{
+  "id": 10,
+  "identifier": "OZDVMO",
+  "persistentUrl": "https://doi.org/10.5072/FK2/OZDVMO",
+  "protocol": "doi",
+  "authority": "10.5072/FK2",
+  "datasetVersion": {
+    "id": 1,
+    "versionNumber": 1,
+    "versionMinorNumber": 0,
+    "versionState": "RELEASED",
+    "productionDate": "Production Date",
+    "lastUpdateTime": "2015-09-29T17:47:35Z",
+    "releaseTime": "2015-09-29T17:47:35Z",
+    "createTime": "2015-09-24T16:47:50Z",
+    "metadataBlocks": {
+      "citation": {
+        "displayName": "Citation Metadata",
+        "fields": [
+          {
+            "typeName": "title",
+            "multiple": false,
+            "typeClass": "primitive",
+            "value": "Spruce Goose"
+          },
+          {
+            "typeName": "author",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "authorName": {
+                  "typeName": "authorName",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "Spruce, Sabrina"
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "datasetContact",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "datasetContactEmail": {
+                  "typeName": "datasetContactEmail",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "spruce@mailinator.com"
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "dsDescription",
+            "multiple": true,
+            "typeClass": "compound",
+            "value": [
+              {
+                "dsDescriptionValue": {
+                  "typeName": "dsDescriptionValue",
+                  "multiple": false,
+                  "typeClass": "primitive",
+                  "value": "What the Spruce Goose was really made of."
+                }
+              }
+            ]
+          },
+          {
+            "typeName": "subject",
+            "multiple": true,
+            "typeClass": "controlledVocabulary",
+            "value": [
+              "Other"
+            ]
+          }
+        ]
+      }
+    },
+    "files": [
+    ],
+    "citation": "Spruce, Sabrina, 2015, \"Spruce Goose\", https://doi.org/10.5072/FK2/OZDVMO,  Root Dataverse,  V1"
+  }
+}


### PR DESCRIPTION
This pull request is only related to change "Alternative Title" by  "AlternativeTitle" and Geolocations related code. http://schema.datacite.org/meta/kernel-4.1/include/datacite-titleType-v4.xsd, marks valid title types and http://schema.datacite.org/meta/kernel-4.1/metadata.xsd , the geoLocations structure. Is not easy to put Datavese gelocation coordinates in OpenAIRE. Dataverse requests North, South, East and West coordinates, but OpenAIRE requests a point or a polygon. If the four coordinates are sets, OpenAIRE polygon can be defined but sometimes it is not the case. 

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #ISSUE_NUMBER: ISSUE_TITLE

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
